### PR TITLE
Show the license in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ authors = [
 ]
 description = "Calculate code metrics in various languages"
 readme = "README.md"
-license = { text = "CC BY-NC 4.0", file = "LICENSE" }
+license = "CC BY-NC 4.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ authors = [
 ]
 description = "Calculate code metrics in various languages"
 readme = "README.md"
+license = { text = "CC BY-NC 4.0", file = "LICENSE" }
 requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 description = "Calculate code metrics in various languages"
 readme = "README.md"
-license = "CC BY-NC 4.0"
+license = "CC-BY-NC-4.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.9"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,13 @@ classifiers = [
 ]
 dynamic = ["dependencies", "version"]
 
+[project.optional-dependencies]
+dev = [
+    "black>=24.1.1",
+    "pytest",
+    "pytest-cov"
+]
+
 [project.scripts]
 modernmetric = "modernmetric.__main__:main"
 modernmetric-test = "test.test_self_scan:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
-black>=24.1.1
 chardet>=5.1.0
 httpx[http2]~=0.28.1
 pygments>=2.15.1
 pygments-tsx>=1.0.1
 pygount
-pytest
-pytest-cov
 cachehash~=1.0.3


### PR DESCRIPTION
Changes:
- Add license information to the `pyproject.toml` file so that it shows in "pip show modernmetric":
```
sean@DESKTOP-FO049FH:~/2024_10_08$ pip show modernmetric
Name: modernmetric
Version: 2025.2.24143409
Summary: Calculate code metrics in various languages
Home-page: https://github.com/verinfast/modernmetric
Author:
Author-email: Jason Nichols <github@verinfast.com>
License-Expression: CC-BY-NC-4.0
Location: /home/ssean/.pyenv/versions/3.9.0/lib/python3.9/site-packages
Requires: cachehash, chardet, httpx, pygments, pygments-tsx, pygount
Required-by: verinfast
```
- Had to move black (and pytest) to dev dependencies in pyproject.toml, because I couldn't install from Test PyPi to test this PR:
```
sean@DESKTOP-FO049FH:~$ pip install -i https://test.pypi.org/simple/ modernmetric==2025.2.24142533
Looking in indexes: https://test.pypi.org/simple/
Collecting modernmetric==2025.2.24142533
  Downloading https://test-files.pythonhosted.org/packages/71/e1/57d1c7be3c983ce26393bc66e4532d3e141cd437267a6fe1db6c1d545686/modernmetric-2025.2.24142533-py3-none-any.whl.metadata (8.7 kB)
INFO: pip is looking at multiple versions of modernmetric to determine which version is compatible with other requirements. This could take a while.
ERROR: Could not find a version that satisfies the requirement black>=24.1.1 (from modernmetric) (from versions: 18.9b0, 2022.8.14a0, 2022.8.14a1, 2022.8.14a2, 2022.8.14a3, 2022.9.26a0)
ERROR: No matching distribution found for black>=24.1.1
```
pyproject.toml documentation lists multiple ways to add a license to a project: https://packaging.python.org/en/latest/guides/licensing-examples-and-user-scenarios/#licensing-example-basic

With our method using "license" using a SPDX identifier, "license-files" pointing to the project included license, and "License :: Free for non-commercial use" classifier, results in PyPi making the licensing very clear:
![image](https://github.com/user-attachments/assets/583274dc-e294-4466-abe5-8d82902851fe)
