### PR TITLE
Ensure cache is valid before using

### DIFF
--- a/modernmetric/fp.py
+++ b/modernmetric/fp.py
@@ -86,7 +86,7 @@ def file_process(_file, _args, _importer, cache: Optional[Cache] = None):
 
         # Store in cache if available
         if cache is not None and not getattr(_args, "no_cache", False):
-            cache.set(_file, json.dumps(resDict))
+            cache.set(_file, resDict)
 
         return result
 

--- a/modernmetric/fp.py
+++ b/modernmetric/fp.py
@@ -1,6 +1,5 @@
 import sys
 import chardet
-import json
 from typing import Optional
 from pygments import lexers
 from pygments_tsx.tsx import patch_pygments

--- a/modernmetric/fp.py
+++ b/modernmetric/fp.py
@@ -27,7 +27,7 @@ def file_process(_file, _args, _importer, cache: Optional[Cache] = None):
                 and cached_result.get("lexer_name")
                 and cached_result.get("tokens")
                 and cached_result.get("store")
-                ):
+            ):
                 return (
                     cached_result["res"],
                     cached_result["file"],

--- a/modernmetric/fp.py
+++ b/modernmetric/fp.py
@@ -1,5 +1,6 @@
 import sys
 import chardet
+import json
 from typing import Optional
 from pygments import lexers
 from pygments_tsx.tsx import patch_pygments
@@ -18,7 +19,15 @@ def file_process(_file, _args, _importer, cache: Optional[Cache] = None):
     if cache is not None and not getattr(_args, "no_cache", False):
         try:
             cached_result = cache.get(_file)
-            if cached_result is not None:
+            if (
+                cached_result is not None
+                and isinstance(cached_result, dict)
+                and cached_result.get("res")
+                and cached_result.get("file")
+                and cached_result.get("lexer_name")
+                and cached_result.get("tokens")
+                and cached_result.get("store")
+                ):
                 return (
                     cached_result["res"],
                     cached_result["file"],
@@ -77,7 +86,7 @@ def file_process(_file, _args, _importer, cache: Optional[Cache] = None):
 
         # Store in cache if available
         if cache is not None and not getattr(_args, "no_cache", False):
-            cache.set(_file, resDict)
+            cache.set(_file, json.dumps(resDict))
 
         return result
 


### PR DESCRIPTION
It turns out that cachehash.get returns the results of a json.loads(), so it IS returning a dictionary in this case, since a dictionary is passed in. 

However, I added more code to make MM work even if cachehash fails or returns bad data.

I will patch cachehash in another PR for cachehash.

## Summary by Sourcery

This pull request improves the resilience of the application by validating the data returned from the cache before using it, and by storing the cache as a JSON string.

Bug Fixes:
- Fixes an issue where the application would crash if the cache returned invalid data.

Enhancements:
- Adds validation to ensure that the data returned from the cache is valid before using it.
- Caches the result of `file_process` as a JSON string.