### PR TITLE
Remove sample checking for now

### DIFF
--- a/modernmetric/fp.py
+++ b/modernmetric/fp.py
@@ -112,7 +112,7 @@ def file_process(_file, _args, _importer, cache: Optional[Cache] = None):
             if _args.ignore_lexer_errors:
                 return (res, old_file, "unknown", [], store)
             else:
-                raise ValueError("No lexer found for file: " + _file) 
+                raise ValueError("No lexer found for file: " + _file)
 
         if os.path.getsize(_file) == 0:
             return (res, old_file, _lexer.name, [], store)


### PR DESCRIPTION
It produces unwanted results for some files.

## Summary by Sourcery

Remove sample-based lexer guessing in file_process and streamline to a single get_lexer_for_filename call with unified error handling

Bug Fixes:
- Eliminate sample-based lexing to prevent incorrect lexer detections

Enhancements:
- Remove fallback guessers (guess_lexer_for_filename and guess_lexer) and rely solely on get_lexer_for_filename
- Add explicit None check after lexer retrieval and handle missing lexers uniformly