### PR TITLE
Package updates and copyright year

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         strategy:
           matrix:
             os: [ubuntu-latest]
-            python-version: ["3.11", "3.12", "3.13", "3.x"]
+            python-version: ["3.11", "3.12", "3.13", "3.14"]
         runs-on: ${{ matrix.os }}
 
         steps:
@@ -57,7 +57,7 @@ jobs:
           uses: actions/cache@v3
           with:
             path: ~/.cache/pip
-            key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+            key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
             restore-keys: |
                 ${{ runner.os }}-pip-
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         strategy:
           matrix:
             os: [ubuntu-latest]
-            python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.x"]
+            python-version: ["3.11", "3.12", "3.13", "3.x"]
         runs-on: ${{ matrix.os }}
 
         steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
           run: |
             python3 -m pip install --upgrade pip
             python3 -m pip install build hatchling
-            python3 -m pip install -e .
+            python3 -m pip install -e ".[dev]"
 
         - name: Run Pytest with coverage
           run: pytest --cov --cov-report=xml

--- a/BSD_LICENSE
+++ b/BSD_LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2024, StartOS, Inc
+Copyright (c) 2026, StartOS, Inc
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE
+++ b/LICENSE
@@ -86,7 +86,7 @@ To the extent possible, if any provision of this Public License is deemed unenfo
 No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
 Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
 
-Copyright 2024-2025 StartOS Inc.
+Copyright 2024-2026 StartOS Inc.
 
 Code committed prior to October 26th, 2024 remains the copyright of Jason Nichols, the previous maintainer of the repository under the BSD 2-Clause License (see BSD_LICENSE)
 

--- a/make_version.py
+++ b/make_version.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 
-
 # Get the version from the git tag, and write to VERSION.
 ref = None
 if "GITHUB_REF" in os.environ:

--- a/modernmetric/__main__.py
+++ b/modernmetric/__main__.py
@@ -22,8 +22,7 @@ def ArgParser(custom_args=None):
         formatter_class=argparse.RawTextHelpFormatter,
         prog="modernmetric",
         description="Calculate code metrics in various languages",
-        epilog=textwrap.dedent(
-            """
+        epilog=textwrap.dedent("""
         Currently you could import files of the following types for --warn_* or --coverage  # noqa: E501
 
         Following information can be read
@@ -45,8 +44,7 @@ def ArgParser(custom_args=None):
                  "content": <content>,
                  "severity": <severity>
              }
-        """
-        ),
+        """),
     )
     parser.add_argument(
         "--output_file", default=None, help="File to write the output to"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ requires = [
     "setuptools",
     "setuptools_scm[toml]>=6.0",
     "build",
-    "hatch-requirements-txt"
 ]
 build-backend = "hatchling.build"
 
@@ -17,7 +16,7 @@ description = "Calculate code metrics in various languages"
 readme = "README.md"
 license = "CC-BY-NC-4.0"
 license-files = ["LICENSE"]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
@@ -32,13 +31,21 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Software Development :: Quality Assurance",
 ]
-dynamic = ["dependencies", "version"]
+dependencies = [
+    "chardet>=5.2.0",
+    "httpx[http2]~=0.28.1",
+    "pygments>=2.19.2",
+    "pygments-tsx>=1.0.3",
+    "pygount>=3.1.1",
+    "cachehash>=1.1.3",
+]
+dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
-    "black>=24.1.1",
-    "pytest",
-    "pytest-cov"
+    "black>=26.1.0",
+    "pytest>=9.0.2",
+    "pytest-cov>=7.0.0"
 ]
 
 [project.scripts]
@@ -52,7 +59,7 @@ modernmetric-test = "test.test_self_scan:main"
 
 [tool.black]
 line-length = 88
-target-version = ['py39', 'py310', 'py311']
+target-version = ['py311', 'py312', 'py313']
 include = '\.pyi?$'
 exclude = '''
 (
@@ -71,6 +78,3 @@ include = ["modernmetric*", "test*"]
 
 [tool.hatch.version]
 path = "VERSION.py"
-
-[tool.hatch.metadata.hooks.requirements_txt]
-files = ["requirements.txt"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "pygments>=2.19.2",
     "pygments-tsx>=1.0.3",
     "pygount>=3.1.1",
-    "cachehash>=1.1.3",
+    "cachehash>=1.1.4",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "chardet>=5.2.0",
     "httpx[http2]~=0.28.1",
     "pygments>=2.19.2",
-    "pygments-tsx>=1.0.3",
+    "pygments-tsx>=1.0.4",
     "pygount>=3.1.1",
     "cachehash>=1.1.4",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-chardet>=5.2.0
-httpx[http2]~=0.28.1
-pygments>=2.15.1
-pygments-tsx>=1.0.1
-pygount
-cachehash>=1.1.0


### PR DESCRIPTION
## Summary by Sourcery

Update packaging configuration and minimum supported Python version while modernizing dependencies and tooling targets.

Enhancements:
- Specify runtime dependencies directly in pyproject instead of using a requirements.txt-based hatch metadata hook.
- Raise the minimum supported Python version to 3.11 and update Black target versions to match newer Python releases.
- Refresh development dependency versions for formatting and testing tools.

Build:
- Simplify build requirements by removing the hatch-requirements-txt plugin and associated configuration, relying solely on hatchling.